### PR TITLE
Fix #12 by ignoring all invalid cookies

### DIFF
--- a/bin/epg-grabber.js
+++ b/bin/epg-grabber.js
@@ -53,7 +53,9 @@ async function main() {
     curl: options.curl,
     lang: options.lang,
     delay: options.delay,
-    request: {}
+    request: {
+        ignoreCookieErrors: true,
+    }
   })
 
   if (options.timeout) config.request.timeout = options.timeout


### PR DESCRIPTION
* Fix #12: ignore cookie errors.

epg-grabber sometimes fails silently due to invalid cookie errors. An error is printed, but the exit code is still zero.

It looks something like this:

> ERROR: Cookie not in this host's domain. Cookie:horizon.tv Request:static.spark.telenet.tv

This PR configures axios with the option `ignoreCookieErrors = true`, which gets rid of the error. 

Since invalid cookies seem to be set server side in some cases, ignoring them seems to be the only option.  