### PR TITLE
Fix merge polluting default config.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export class EPGGrabber {
     if (!(channel instanceof Channel))
       throw new Error('The first argument must be the "Channel" class')
 
-    config = merge(defaultConfig, config, this.globalConfig)
+    config = merge({}, defaultConfig, config, this.globalConfig)
 
     if (typeof config.logo !== 'function') return null
 
@@ -59,7 +59,7 @@ export class EPGGrabber {
 
     const utcDate = getUTCDate(date)
 
-    config = merge(defaultConfig, config, this.globalConfig)
+    config = merge({}, defaultConfig, config, this.globalConfig)
 
     if (!config.parser) throw new Error('Could not find parser() in the config file')
     if (!config.site) throw new Error("The required 'site' property is missing")
@@ -175,7 +175,7 @@ export class EPGGrabberMock extends EPGGrabber {
 
     const utcDate = getUTCDate(date)
 
-    config = merge(defaultConfig, config, this.globalConfig)
+    config = merge({}, defaultConfig, config, this.globalConfig)
 
     if (!config.parser) throw new Error('Could not find parser() in the config file')
 


### PR DESCRIPTION
While running EPG with following channels:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<channels>
  <channel site="mncvision.id" site_id="84" lang="id" xmltv_id="SindoNewsTV.id@SD">Sindo News TV</channel>
  <channel site="tivie.id" site_id="garudatv" lang="id" xmltv_id="GarudaTV.id@SD">Garuda TV</channel>
</channels>
```

```sh
npm run grab --- --channels=./curated.xml --days=1 --timeout=5000 --debug

> grab
> tsx scripts/commands/epg/grab.ts --channels=./curated.xml --days=1 --timeout=5000 --debug

info starting...
debug config: {
  "request": {
    "timeout": 5000
  },
  "days": 1,
  "debug": true
}
info loading channels...
info found 2 channel(s)
info loading api data...
info creating queue...
info run:
debug request: {
  "transitional": {
    "silentJSONParsing": true,
    "forcedJSONParsing": true,
    "clarifyTimeoutError": false
  },
  "adapter": [
    "xhr",
    "http",
    "fetch"
  ],
  "transformRequest": [
    null
  ],
  "transformResponse": [
    null
  ],
  "timeout": 5000,
  "xsrfCookieName": "XSRF-TOKEN",
  "xsrfHeaderName": "X-XSRF-TOKEN",
  "maxContentLength": 5242880,
  "maxBodyLength": -1,
  "env": {},
  "headers": {
    "Accept": "application/json, text/plain, */*",
    "Content-Type": "application/x-www-form-urlencoded",
    "Cookie": "s1nd0vL=jk6gkj2tbd1hgm43cc6te7cd6ifdrk9q"
  },
  "cache": false,
  "method": "post",
  "withCredentials": true,
  "responseType": "arraybuffer",
  "jar": null,
  "data": {},
  "url": "https://www.mncvision.id/schedule/table",
  "allowAbsoluteUrls": true
}
info   [1/2] mncvision.id (id) - SindoNewsTV.id@SD - Nov 11, 2025 (25 programs)
debug request: {
  "transitional": {
    "silentJSONParsing": true,
    "forcedJSONParsing": true,
    "clarifyTimeoutError": false
  },
  "adapter": [
    "xhr",
    "http",
    "fetch"
  ],
  "transformRequest": [
    null
  ],
  "transformResponse": [
    null
  ],
  "timeout": 5000,
  "xsrfCookieName": "XSRF-TOKEN",
  "xsrfHeaderName": "X-XSRF-TOKEN",
  "maxContentLength": 5242880,
  "maxBodyLength": -1,
  "env": {},
  "headers": {
    "Accept": "application/json, text/plain, */*",
    "Content-Type": "application/x-www-form-urlencoded",
    "Cookie": "s1nd0vL=jk6gkj2tbd1hgm43cc6te7cd6ifdrk9q"
  },
  "cache": false,
  "method": "post",
  "withCredentials": true,
  "responseType": "arraybuffer",
  "jar": null,
  "data": {},
  "url": "https://tivie.id/channel/garudatv/20251111",
  "allowAbsoluteUrls": true
}
info   [2/2] tivie.id (id) - GarudaTV.id@SD - Nov 11, 2025 (0 programs)
info     ERR: Request failed with status code 405
info   saving to "guide.xml"...
success   done in 00h 00m 05s
```

As seen above, `mncvision.id` site configuration for `headers` and `method` also passed to `tivie.id` when making request causing the error 405.